### PR TITLE
Fix btrfs_device_report for similar device paths

### DIFF
--- a/btrfs_device_report
+++ b/btrfs_device_report
@@ -97,7 +97,7 @@ do
 	# capture the disk id (key) and value of each line
 	# regex1: get stuff in [brackets], regex2: get the first 9 chars after last /
 	if [ "${verbose}" == "0" ]; then
-		key=$( echo $p | sed -E "s/\[(.*)\].*/\1/" | sed -E "s/.*\/([^/]{1,${mapping_length}}).*/\1/" )
+		key=$( echo $p | sed -E "s/\[(.*)\].*/\1/" | sed -E "s/.*\/([^/]*)/\1/" )
 	else
 		key=$( echo $p | sed -E "s/\[(.*)\].*/\1/" )
 	fi
@@ -130,7 +130,7 @@ do
 
 	# if the key changed, put key value, otherwise just value
 	if [ "${key}" != "${lastkey}" ]; then
-		printf "%-${longest_path}s  %-${mapping_length}s  %-${longest_device}s  %${valuesize}s" "${path}" "${key}" "${device}" "${value}" 
+		printf "%-${longest_path}s  %-${mapping_length}.${mapping_length}s  %-${longest_device}s  %${valuesize}s" "${path}" "${key}" "${device}" "${value}" 
 	else
 		if [ "${verbose}" == "0" ]; then
 			printf "%${valuesize}s" "${value}"


### PR DESCRIPTION
The btrfs device reports prints incorrectly when the first several characters of a device path are the same due to truncating the device path before storing it as the key in the print loop: 

````
titan:~/storage-scripts # ./btrfs_device_report
BTRFS_PATH              MAPPING    DEVICE   WRFCG
/mnt/tachikoma          luks-WD10  sda/dev/sdb/dev/sdc  .....xx.xx.....
titan:~/storage-scripts #
titan:~/storage-scripts # ./btrfs_device_report -v
BTRFS_PATH              MAPPING                              DEVICE        Write IO   Read IO  Flush IO   Corrupt  Generate
/mnt/tachikoma          /dev/mapper/luks-WD100EFAX-2Yxxxxxx /dev/sdb             0         0         0         0         0
/mnt/tachikoma          /dev/mapper/luks-WD100EFAX-2Yxxxxxx /dev/sda          3049      2985         0     12589        12
/mnt/tachikoma          /dev/mapper/luks-WD100EFAX-2Yxxxxxx /dev/sdd             0         0         0         0         0
titan:~/storage-scripts #

````



This change uses the full device path as a key, and truncates it only when printing the table.
````
BTRFS_PATH              MAPPING    DEVICE   WRFCG
/mnt/tachikoma          luks-WD10  sdb      .....
/mnt/tachikoma          luks-WD10  sda      xx.xx
/mnt/tachikoma          luks-WD10  sdc      .....
````
